### PR TITLE
use `NSData.WritingOptions.atomic` instead

### DIFF
--- a/Sources/CodableFiles/CodableFiles.swift
+++ b/Sources/CodableFiles/CodableFiles.swift
@@ -113,7 +113,7 @@ public extension CodableFiles {
 
         // Write data to file url.
         let data = try JSONSerialization.data(withJSONObject: objectDictionary, options: [.prettyPrinted])
-        try data.write(to: fileURL, options: [.atomicWrite])
+        try data.write(to: fileURL, options: [.atomic])
         return fileURL
     }
 
@@ -150,7 +150,7 @@ public extension CodableFiles {
 
         // Write data to file url.
         let data = try JSONSerialization.data(withJSONObject: objectDictionary, options: [.prettyPrinted])
-        try data.write(to: fileURL, options: [.atomicWrite])
+        try data.write(to: fileURL, options: [.atomic])
         return fileURL
     }
 


### PR DESCRIPTION
I have an issue on compile my project with CodableFiles 1.0.1 as a dependency in swift docker 5.6 
and this PR fixes it by using `NSData.WritingOptions.atomic` instead of `.atomicWrite` on write file 
since`.atomicWrite` has been marked as deprecated.

Thanks for your cool project 🤜